### PR TITLE
Added a rake task parameter to specify the branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ Or if you don't use bundler:
 
 ## Usage
 
-1. Run `rake vendorise:gem[repo_url]` to vendorise the gem hosted at `repo_url` into `/vendor/gems`.
+1. Run `rake "vendorise:gem[repo_url]"` to vendorise the gem hosted at `repo_url` into `/vendor/gems`.
 2. Add `gem '<gem_name>', path: 'vendor/gems/<gem_name>'` to your Gemfile
 
-You can update the gem at any time by running the rake task again. Vendorise always uses the code from the master branch on git (tags are not supported yet).
+You can update the gem at any time by running the rake task again.
+
+By default the `vendorise:gem` rake task will use the master branch. To use another branch (or tag) specify it as the second parameter, like this:
+
+    rake "vendorise:gem[repo_url, branch]"
 

--- a/lib/vendorise/arborist.rb
+++ b/lib/vendorise/arborist.rb
@@ -1,10 +1,11 @@
 module Vendorise
   class Arborist
-    attr_reader :path, :url
+    attr_reader :path, :url, :branch
 
-    def initialize(path, url)
+    def initialize(path, url, branch)
       @path = path
       @url = url
+      @branch = branch
     end
 
     def subtree_already_exists?
@@ -13,7 +14,7 @@ module Vendorise
 
     def subtree_command
       cmd = subtree_already_exists? ? "pull" : "add"
-      "git subtree #{cmd} --prefix #{path} #{url} master --squash"
+      "git subtree #{cmd} --prefix #{path} #{url} #{branch} --squash"
     end
   end
 end

--- a/lib/vendorise/tasks.rb
+++ b/lib/vendorise/tasks.rb
@@ -4,11 +4,13 @@ require_relative "arborist"
 
 namespace :vendorise do
   desc "Installs a gem from the specified url to /vendor/gems"
-  task :gem, :url do |t, args|
+  task :gem, [:url, :branch] do |t, args|
+    args.with_defaults(branch: "master")
     parser = Vendorise::Parser.new(args[:url])
     url = parser.gem_url or raise "Please specify a valid url for the gem"
+    branch = args[:branch]
 
-    command = Vendorise::Arborist.new("vendor/gems/#{parser.gem_name}", url).subtree_command
+    command = Vendorise::Arborist.new("vendor/gems/#{parser.gem_name}", url, branch).subtree_command
 
     sh(command)
   end

--- a/spec/lib/vendorise/arborist_spec.rb
+++ b/spec/lib/vendorise/arborist_spec.rb
@@ -3,19 +3,29 @@ require_relative "../../../lib/vendorise/arborist"
 
 module Vendorise
   describe Arborist do
+    let(:subtree_already_exists?) { false }
+
+    before { allow(subject).to receive(:subtree_already_exists?).and_return(subtree_already_exists?) }
+
+    context "when branch is specified in the constructor" do
+      subject { Arborist.new "foo/bar", "git@github.com:New-Bamboo/vendorise.git", "development" }
+
+      it "makes #subtree_command use that branch" do
+        expect(subject.subtree_command).to eq "git subtree add --prefix foo/bar git@github.com:New-Bamboo/vendorise.git development --squash"
+      end
+    end
+
     describe :subtree_already_exists? do
-      subject { Arborist.new "foo/bar", "git@github.com:New-Bamboo/vendorise.git" }
+      subject { Arborist.new "foo/bar", "git@github.com:New-Bamboo/vendorise.git", "master" }
 
       context "is false" do
-        before { allow(subject).to receive(:subtree_already_exists?).and_return(false) }
-
         it "makes #subtree_command use 'git subtree add'" do
           expect(subject.subtree_command).to eq "git subtree add --prefix foo/bar git@github.com:New-Bamboo/vendorise.git master --squash"
         end
       end
 
       context "is true" do
-        before { allow(subject).to receive(:subtree_already_exists?).and_return(true) }
+        let(:subtree_already_exists?) { true }
 
         it "makes #subtree_command use 'git subtree pull'" do
           expect(subject.subtree_command).to eq "git subtree pull --prefix foo/bar git@github.com:New-Bamboo/vendorise.git master --squash"

--- a/spec/lib/vendorise/arborist_spec.rb
+++ b/spec/lib/vendorise/arborist_spec.rb
@@ -3,21 +3,21 @@ require_relative "../../../lib/vendorise/arborist"
 
 module Vendorise
   describe Arborist do
-    describe :subtree_command do
+    describe :subtree_already_exists? do
       subject { Arborist.new "foo/bar", "git@github.com:New-Bamboo/vendorise.git" }
 
-      context "when #subtree_already_exists? is false" do
+      context "is false" do
         before { allow(subject).to receive(:subtree_already_exists?).and_return(false) }
 
-        it "is git subtree add" do
+        it "makes #subtree_command use 'git subtree add'" do
           expect(subject.subtree_command).to eq "git subtree add --prefix foo/bar git@github.com:New-Bamboo/vendorise.git master --squash"
         end
       end
 
-      context "when #subtree_already_exists? is true" do
+      context "is true" do
         before { allow(subject).to receive(:subtree_already_exists?).and_return(true) }
 
-        it "is git subtree pull" do
+        it "makes #subtree_command use 'git subtree pull'" do
           expect(subject.subtree_command).to eq "git subtree pull --prefix foo/bar git@github.com:New-Bamboo/vendorise.git master --squash"
         end
       end

--- a/spec/lib/vendorise/tasks_spec.rb
+++ b/spec/lib/vendorise/tasks_spec.rb
@@ -10,7 +10,7 @@ module Vendorise
     end
 
     it "accepts a url argument" do
-      expect(task.arg_names).to match_array [:url]
+      expect(task.arg_names).to match_array [:url, :branch]
     end
   end
 end

--- a/spec/lib/vendorise_spec.rb
+++ b/spec/lib/vendorise_spec.rb
@@ -2,18 +2,14 @@ require_relative "../spec_helper"
 require_relative "../../lib/vendorise"
 
 describe "vendorise" do
-  after(:each) do
-    # remove expect_any_instance_of stubs
-    RSpec::Mocks.space.reset_all
-  end
-
-  it "adds a rake task to run git subtree" do
+  it "adds a rake task to run git subtree", :clear_mocks do
     expect_any_instance_of(Rake::FileUtilsExt).to receive(:sh).with("git subtree add --prefix vendor/gems/sinatra git@github.com:sinatra/sinatra.git master --squash")
     Rake.application.invoke_task "vendorise:gem[git@github.com:sinatra/sinatra.git]"
   end
 
-  it "uses the (optional) second argument to select the branch" do
+  it "uses the (optional) second argument to select the branch", :clear_mocks do
     expect_any_instance_of(Rake::FileUtilsExt).to receive(:sh).with("git subtree add --prefix vendor/gems/sinatra git@github.com:sinatra/sinatra.git 1.3.x --squash")
     Rake.application.invoke_task "vendorise:gem[git@github.com:sinatra/sinatra.git, 1.3.x]"
   end
 end
+

--- a/spec/lib/vendorise_spec.rb
+++ b/spec/lib/vendorise_spec.rb
@@ -2,8 +2,18 @@ require_relative "../spec_helper"
 require_relative "../../lib/vendorise"
 
 describe "vendorise" do
+  after(:each) do
+    # remove expect_any_instance_of stubs
+    RSpec::Mocks.space.reset_all
+  end
+
   it "adds a rake task to run git subtree" do
     expect_any_instance_of(Rake::FileUtilsExt).to receive(:sh).with("git subtree add --prefix vendor/gems/sinatra git@github.com:sinatra/sinatra.git master --squash")
-    Rake::Task["vendorise:gem"].invoke("git@github.com:sinatra/sinatra.git")
+    Rake.application.invoke_task "vendorise:gem[git@github.com:sinatra/sinatra.git]"
+  end
+
+  it "uses the (optional) second argument to select the branch" do
+    expect_any_instance_of(Rake::FileUtilsExt).to receive(:sh).with("git subtree add --prefix vendor/gems/sinatra git@github.com:sinatra/sinatra.git 1.3.x --squash")
+    Rake.application.invoke_task "vendorise:gem[git@github.com:sinatra/sinatra.git, 1.3.x]"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,10 @@ RSpec.configure do |config|
   config.expect_with(:rspec){ |c| c.syntax = :expect }
   config.mock_with(:rspec){ |c| c.syntax = :expect }
 
+  # don't complain that I'm using symbols as metadata...
+  config.treat_symbols_as_metadata_keys_with_true_values = true
+  # reseting the mock space doesn't seem to work on jruby
+  config.filter_run_excluding :clear_mocks if RUBY_ENGINE == "jruby"
   config.after(:each, :clear_mocks) do
     # expect_any_instance_of hangs around between specs
     RSpec::Mocks.space.reset_all

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,4 +2,9 @@ RSpec.configure do |config|
   config.order = 'random'
   config.expect_with(:rspec){ |c| c.syntax = :expect }
   config.mock_with(:rspec){ |c| c.syntax = :expect }
+
+  config.after(:each, :clear_mocks) do
+    # expect_any_instance_of hangs around between specs
+    RSpec::Mocks.space.reset_all
+  end
 end


### PR DESCRIPTION
Previously vendorise could only download the master branch. This PR adds an optional rake parameter that allows any branch to be specified.
